### PR TITLE
Add parsec-v3 to nix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-v2:
-    name: "Build parsec-cloud v2"
+  build:
+    strategy:
+      matrix:
+        include:
+          - version: v2
+            build-timeout-minutes: 80 # 1h20m
+          - version: v3
+            build-timeout-minutes: 10
+      fail-fast: false
+    name: "Build parsec-cloud ${{ matrix.version }}"
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
@@ -43,13 +51,9 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
         timeout-minutes: 1
 
-      - name: Patch parsec-cloud source
-        run: nix build .#parsec-cloud-v2-src
-        timeout-minutes: 1
-
       - name: Build parsec-cloud client
-        run: nix build .#parsec-cloud-v2-client
-        timeout-minutes: 80 # 1h20m
+        run: nix build .#parsec-cloud-${{ matrix.version }}-client
+        timeout-minutes: ${{ matrix.build-timeout-minutes }}
 
       - name: Check flake
         run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.cargo
 /cargo-vendor-dir
 /straces
+/client
+/electron

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Packaging parsec-cloud in NixOS
     - [Packaging python - Nixos Wiki](https://nixos.wiki/wiki/Packaging/Python)
     - [`nixpkgs.fetchPypi`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchpypi/default.nix)
   - [NixosRust](https://nixos.org/manual/nixpkgs/stable/#rust)
+  - [Nixos node](https://nixos.org/manual/nixpkgs/stable/#language-javascript)
+    - [npm packages](https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/development/node-packages/node-packages.nix)
+    - [nixos vscode](https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/applications/editors/vscode/generic.nix)
+    - [wiki vscode](https://nixos.wiki/wiki/Visual_Studio_Code)
+  - [Nixos Rust](https://nixos.org/manual/nixpkgs/stable/#rust)
+    - [wiki Rust](https://nixos.wiki/wiki/Rust)
 
 - Nix Derivations:
   - [`mkDerivation` hooks](https://nixos.org/manual/nixpkgs/stable/#chap-hooks)

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1711779695,
+        "narHash": "sha256-iGb6ptUaNBOCftKnNJiWT5z1ftngfNtwqJkD8Z9Vwfw=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "aaeaf4574767a0f5ed1787e990139aefcf4db103",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -81,8 +102,26 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "poetry2nix": "poetry2nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1711731711,
+        "narHash": "sha256-dyezzeSbWMpflma+E9USmvSxuLgGcNGcGw3cOnX36ko=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "f5a9250147f6569d8d89334dc9cca79c0322729f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/packages/v2/home-manager-module.nix
+++ b/packages/v2/home-manager-module.nix
@@ -5,14 +5,14 @@ let
   srcPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v2-src;
 in
 {
-  options.programs.parsec-cloud-client = with lib; {
-    enable = mkEnableOption "parsec-cloud-client";
+  options.programs.parsec-cloud-v2-client = with lib; {
+    enable = mkEnableOption "parsec-cloud-v2-client";
 
     package = mkOption {
       type = types.package;
       default = clientDefaultPackage;
       defaultText = lib.literalExpression ''
-        parsec-cloud.packages.''${pkgs.stdenv.hostPlatform.system}.parsec-cloud-client
+        parsec-cloud.packages.''${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v2-client
       '';
       description = mdDoc ''
         Parsec-cloud client package to use. Defaults to the one provided by the flake.
@@ -232,7 +232,7 @@ in
 
   config =
     let
-      cfgClient = config.programs.parsec-cloud-client;
+      cfgClient = config.programs.parsec-cloud-v2-client;
       client = cfgClient.package;
     in
     lib.mkIf cfgClient.enable {
@@ -286,12 +286,11 @@ in
         ipc_win32_mutex_name = "parsec-cloud";
       };
 
-      # TODO: Add icon
-      xdg.dataFile."applications/parsec-cloud.desktop".text = ''
+      xdg.dataFile."applications/parsec-cloud-v2.desktop".text = ''
         [Desktop Entry]
-        Name=Parsec
+        Name=Parsec Cloud
         Comment=Secure cloud framework
-        Exec=${client}/bin/parsec core gui %u
+        Exec=${client}/bin/parsec core gui %U
         Icon=${srcPackage.icons}/parsec.png
         Terminal=false
         Type=Application

--- a/packages/v3/electron-app.nix
+++ b/packages/v3/electron-app.nix
@@ -1,0 +1,59 @@
+{ pkgs, src, client-build, libparsec, ... }:
+
+let
+  pkgVersion = libparsec.version;
+  pkgMajor = pkgs.lib.versions.major pkgVersion;
+  pname = "parsec-v${pkgMajor}";
+in
+pkgs.buildNpmPackage {
+  inherit pname;
+  version = pkgVersion;
+  outputs = [ "out" "icon" ];
+
+  src = "${src}/client/electron";
+
+  npmDepsHash = "sha256-kOGJtJkwkU8/N1iVW23OaRcEdVxn0cLKodRufRbrV4g=";
+
+  configurePhase = ''
+    mkdir -pv build/{,generated-ts/}src app
+    install -v -p -m 444 ${libparsec.typing}/libparsec.d.ts build/generated-ts/src/libparsec.d.ts
+    install -v -p -m 555 ${libparsec}/libparsec.node build/src/libparsec.node
+    cp -ra ${client-build}/. app
+  '';
+
+  # prevent electron download from electron in package.json
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  };
+
+  buildPhase = ''
+    npx tsc
+    node package.js --mode prod --platform linux --export > electron-builder-config.json
+    npm exec electron-builder -- \
+      --linux \
+      --dir \
+      --config=electron-builder-config.json \
+      --config.electronDist=${pkgs.electron_28}/libexec/electron \
+      --config.electronVersion=${pkgs.electron_28.version}
+  '';
+
+  # Inspired by https://github.com/NixOS/nixpkgs/blob/af105fd3758230351db538ade56e862ac947f849/pkgs/development/tools/electron/wrapper.nix
+  installPhase = ''
+    mkdir -pv $out/bin
+    cp -r dist/linux-unpacked $out/libexec
+
+    gappsWrapperArgsHook
+    makeBinaryWrapper $out/libexec/${pname} $out/bin/${pname} \
+      "''${gappsWrapperArgs[@]}" \
+      --set CHROME_DEVEL_SANDBOX $out/libexec/chrome-sandbox
+
+    cp -rva assets/icon.png $icon
+  '';
+
+  nativeBuildInputs = [ pkgs.wrapGAppsHook pkgs.makeWrapper pkgs.patchelf ];
+  dontWrapGApps = true;
+
+  meta = libparsec.meta // {
+    description = "Open source Dropbox-like file sharing with full client encryption !";
+  };
+}

--- a/packages/v3/home-manager-module.nix
+++ b/packages/v3/home-manager-module.nix
@@ -1,0 +1,44 @@
+self: { lib, pkgs, config, ... }:
+
+let
+  clientDefaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v3-client;
+in
+{
+  options.programs.parsec-cloud-v3-client = with lib; {
+    enable = mkEnableOption "parsec-cloud-v3-client";
+
+    package = mkOption {
+      type = types.package;
+      default = clientDefaultPackage;
+      defaultText = lib.literalExpression ''
+        parsec-cloud.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v3-client
+      '';
+      description = mdDoc ''
+        Parsec-cloud client package to use. Defaults to the one provided by the flake.
+      '';
+    };
+  };
+
+  config =
+    let
+      cfgClient = config.programs.parsec-cloud-v3-client;
+      client = cfgClient.package;
+      clientMajorVersion = lib.versions.major client.version;
+      icon = client.icon;
+      desktopItem = pkgs.makeDesktopItem {
+        name = "Parsec Cloud v${clientMajorVersion}";
+        desktopName = "Parsec Cloud";
+        comment = "Secure cloud framework";
+        exec = "${client}/bin/parsec-v${clientMajorVersion} %U";
+        inherit icon;
+        terminal = false;
+        categories = [ "Office" "FileTransfer" "Filesystem" "Security" ];
+        mimeTypes = [ "x-scheme-handler/parsec${clientMajorVersion}" ];
+      };
+    in
+    lib.mkIf cfgClient.enable {
+      home.packages = [ client ];
+
+      xdg.dataFile."applications/parsec-cloud-v${clientMajorVersion}.desktop".source = "${desktopItem}/share/applications/parsec-v${clientMajorVersion}.desktop";
+    };
+}

--- a/packages/v3/libparsec-node.nix
+++ b/packages/v3/libparsec-node.nix
@@ -1,0 +1,49 @@
+{ pkgs, version, src, rust-toolchain, system, ... }:
+
+(pkgs.makeRustPlatform {
+  cargo = rust-toolchain;
+  rustc = rust-toolchain;
+}).buildRustPackage
+{
+  inherit version src;
+  name = "libparsec-node-module";
+  outputs = [ "out" "typing" ];
+
+  # Crate to build
+  buildAndTestSubdir = "bindings/electron";
+  cargoBuildFeatures = [ ];
+
+  cargoLock.lockFile = "${src}/Cargo.lock";
+  cargoHash = pkgs.lib.fakeHash;
+
+  doCheck = false;
+
+  # Copy file after fixup.
+  postFixup =
+    let
+      artifact_name = "liblibparsec_bindings_electron.so";
+      typescript_def_path = "bindings/electron/src/index.d.ts";
+    in
+    ''
+      install -v -m 555 -p $out/lib/${artifact_name} $out/libparsec.node
+      install -v --directory $typing
+      install -v -m 444 -p $src/${typescript_def_path} $typing/libparsec.d.ts
+    '';
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = with pkgs;
+    [
+      openssl
+      sqlite
+      fuse3
+    ];
+
+  meta = with pkgs.lib; {
+    homepage = "https://parsec.cloud/";
+    description = "Parsec library for Node.js";
+    branch = "releases/${majorMinor version}";
+    license = [ licenses.bsl11 ];
+    changelog = "https://github.com/Scille/parsec-cloud/tree/v${version}/HISTORY.rst";
+    platforms = [ system ];
+  };
+}

--- a/packages/v3/native-build.nix
+++ b/packages/v3/native-build.nix
@@ -1,0 +1,44 @@
+{ pkgs, src, version, ... }:
+
+pkgs.buildNpmPackage {
+  inherit version;
+  pname = "parsec-native-build";
+
+  src = "${src}/client";
+
+  npmDepsHash = "sha256-NaWKKuw9xquHPiJbrgcIjO6xQn/52ljIo3yWwdx4tJI=";
+
+  prePatch =
+    let
+      buildCmd = "vite build --mode=production";
+    in
+    ''
+      set -e
+      sed \
+        -e '/postinstall/d' \
+        -e 's;node ./scripts/vite_build_for_native.cjs;${buildCmd};' \
+        -i package.json
+    '';
+
+  env =
+    {
+      PLATFORM = "native";
+      CYPRESS_INSTALL_BINARY = "0";
+    };
+
+  npmBuildScript = "native:build";
+
+  installPhase = ''
+    mkdir -p $out
+    cp -rva dist/{index.html,assets} $out
+  '';
+
+  meta = with pkgs.lib; {
+    homepage = "https://parsec.cloud/";
+    description = "Parsec cloud native client build used for the electron app";
+    branch = "releases/${majorMinor version}";
+    license = [ licenses.bsl11 ];
+    changelog = "https://github.com/Scille/parsec-cloud/tree/v${version}/HISTORY.rst";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Breaking changes
================

Home manager
------------

- [v2 module]: The configuration for `parsec-cloud-client` is renamed to `parsec-cloud-v2-client`.
- The default exposed module is now `parsec-cloud.v3`.

Flake packages
--------------

- Package `parsec-cloud-client` now point to `parsec-cloud-v3-client`.

New Features
============

- Package `parsec-cloud` major version 3 in nix:

  - Provide a package `parsec-cloud-v3-client`.
  - Provide a `home-manager` module.