### PR TITLE
Bump parsec to 3.1.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
       poetry2nix = import inputs.poetry2nix {
         inherit pkgs;
       };
+      # A prelease is denotted is the patch component of a version contain a hyphen ("-")
+      isPrerelease = version: pkgs.lib.strings.hasInfix "-" version;
     in
     {
       formatter.${ system} = pkgs.nixpkgs-fmt;
@@ -81,7 +83,7 @@
                 };
 
                 libparsec-node = import packages/v3/libparsec-node.nix { inherit pkgs version src rust-toolchain system; };
-                native-build = import packages/v3/native-build.nix { inherit pkgs src version; };
+                native-build = import packages/v3/native-build.nix { inherit pkgs src version; isPrerelease = isPrerelease version; };
                 client = import packages/v3/electron-app.nix {
                   inherit pkgs src;
                   client-build = native-build;

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
       poetry2nix = import inputs.poetry2nix {
         inherit pkgs;
       };
-      # A prelease is denotted if version contain a hyphen ("-")
+      # A prelease is denotted if version contain a hyphen.
       isPrerelease = version: pkgs.lib.strings.hasInfix "-" version;
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
       poetry2nix = import inputs.poetry2nix {
         inherit pkgs;
       };
-      # A prelease is denotted is the patch component of a version contain a hyphen ("-")
+      # A prelease is denotted if version contain a hyphen ("-")
       isPrerelease = version: pkgs.lib.strings.hasInfix "-" version;
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -67,12 +67,12 @@
               };
             v3 =
               let
-                version = "3.0.3";
+                version = "3.1.0";
                 # Currently parsec-cloud only provide a nightly release for v3 which change each day.
                 # So fixing the commit_rev to stay on the same version.
-                commit_rev = "128350f9566abe8a6bd313cd93d5d30b367ce13d";
+                commit_rev = "2c0a049584088776a00ba7a639634c9d805c6140";
                 # `nix-prefetch-url --unpack https://github.com/${owner}/${repo}/archive/${commit_rev}.tar.gz`
-                commit_sha256 = "1q4l26angj21jwxr4rdywyz4sz1dprgndb4wjnrfd5sjisqbdjwn";
+                commit_sha256 = "1wbdcgxmiv1kx4g3xjjvc14i2v9qjjmxdklpkhr0hcacs0zzaayh";
               in
               rec {
                 src = pkgs.fetchFromGitHub {

--- a/packages/v3/electron-app.nix
+++ b/packages/v3/electron-app.nix
@@ -12,7 +12,7 @@ pkgs.buildNpmPackage {
 
   src = "${src}/client/electron";
 
-  npmDepsHash = "sha256-FeCn+YxmCCUwrL2fE99hvEnJ3Zu3FSGMyMFyQk/nxC4=";
+  npmDepsHash = "sha256-XnKtqtfIud88DPhVtfJOQ6Ephfb6t4XIBjg3Po/njmI=";
 
   configurePhase = ''
     mkdir -pv build/{,generated-ts/}src app

--- a/packages/v3/native-build.nix
+++ b/packages/v3/native-build.nix
@@ -1,4 +1,4 @@
-{ pkgs, src, version, ... }:
+{ pkgs, src, version, isPrerelease, ... }:
 
 pkgs.buildNpmPackage {
   inherit version;
@@ -12,7 +12,7 @@ pkgs.buildNpmPackage {
 
   prePatch =
     let
-      buildCmd = "vite build --mode=production";
+      buildCmd = "vite build --mode=${if isPrerelease then "release-candidate" else "production"}";
     in
     ''
       set -e

--- a/packages/v3/native-build.nix
+++ b/packages/v3/native-build.nix
@@ -6,7 +6,7 @@ pkgs.buildNpmPackage {
 
   src = "${src}/client";
 
-  npmDepsHash = "sha256-ulj3LgcEDHCaPffOormdPqoPTUCe+XY4CE/8XH8GD48=";
+  npmDepsHash = "sha256-Ui4HWWKm0lJjlGZsU8lPAzRPSXEBnhj9j9LtWH/5uSU=";
 
   makeCacheWritable = true; # Require for megashark-lib that build during a prepare hook.
 


### PR DESCRIPTION
- Change vite build mode depending on if the version is a pre-release
- Improve update script to fail if replacement failed