### PR TITLE
Change schedule time for update to 15:00 each monday

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/update.yml
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1"
+    - cron: "0 15 * * 1"
 
 concurrency:
   group: parsec-cloud-update


### PR DESCRIPTION
nixos-channel seems to be updated after 05:00 (last update was `2025-01-06T07:43:56`), to not miss that update
we delay the schedule to 15:00