### PR TITLE
feat: Add parsec-cli build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,12 @@ jobs:
         timeout-minutes: 1
 
       - name: Build parsec-cloud client
-        run: nix build .#parsec-cloud-${{ matrix.version }}-client
+        run: nix build -L .#parsec-cloud-${{ matrix.version }}-client
+        timeout-minutes: ${{ matrix.build-timeout-minutes }}
+
+      - name: Build parsec-cloud cli
+        if: matrix.version == 'v3'
+        run: nix build -L .#parsec-cloud-${{ matrix.version }}-cli
         timeout-minutes: ${{ matrix.build-timeout-minutes }}
 
       - name: Check flake

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,13 @@
     };
   };
 
-  outputs = { self, nixpkgs, fenix, ... }@inputs:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      fenix,
+      ...
+    }@inputs:
     let
       system = "x86_64-linux";
 
@@ -42,7 +48,7 @@
       isPrerelease = version: pkgs.lib.strings.hasInfix "-" version;
     in
     {
-      formatter.${ system} = pkgs.nixpkgs-fmt;
+      formatter.${system} = pkgs.nixpkgs-fmt;
 
       packages.${system} =
         let
@@ -82,12 +88,32 @@
                   sha256 = commit_sha256;
                 };
 
-                libparsec-node = import packages/v3/libparsec-node.nix { inherit pkgs version src rust-toolchain system; };
-                native-build = import packages/v3/native-build.nix { inherit pkgs src version; isPrerelease = isPrerelease version; };
+                libparsec-node = import packages/v3/libparsec-node.nix {
+                  inherit
+                    pkgs
+                    version
+                    src
+                    rust-toolchain
+                    system
+                    ;
+                };
+                native-build = import packages/v3/native-build.nix {
+                  inherit pkgs src version;
+                  isPrerelease = isPrerelease version;
+                };
                 client = import packages/v3/electron-app.nix {
                   inherit pkgs src;
                   client-build = native-build;
                   libparsec = libparsec-node;
+                };
+                cli = import packages/v3/parsec-cli.nix {
+                  inherit
+                    pkgs
+                    version
+                    src
+                    rust-toolchain
+                    system
+                    ;
                 };
               };
           };
@@ -99,8 +125,10 @@
           parsec-cloud-v3-node-lib = parsec-cloud.v3.libparsec-node;
           parsec-cloud-v3-native-build = parsec-cloud.v3.native-build;
           parsec-cloud-v3-client = parsec-cloud.v3.client;
+          parsec-cloud-v3-cli = parsec-cloud.v3.cli;
 
           parsec-cloud-client = parsec-cloud.v3.client;
+          parsec-cloud-cli = parsec-cloud.v3.cli;
         };
 
       homeManagerModules = rec {
@@ -118,7 +146,8 @@
             nil
             cachix
             gh
-            prefetch-npm-deps;
+            prefetch-npm-deps
+            ;
         };
 
         shellHook = ''

--- a/packages/v2/home-manager-module.nix
+++ b/packages/v2/home-manager-module.nix
@@ -1,234 +1,243 @@
-self: { lib, pkgs, config, ... }:
+self:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 
 let
   clientDefaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v2-client;
   srcPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v2-src;
 in
 {
-  options.programs.parsec-cloud-v2-client = let inherit (lib) mkEnableOption mkOption types; in {
-    enable = mkEnableOption "parsec-cloud-v2-client";
+  options.programs.parsec-cloud-v2-client =
+    let
+      inherit (lib) mkEnableOption mkOption types;
+    in
+    {
+      enable = mkEnableOption "parsec-cloud-v2-client";
 
-    package = mkOption {
-      type = types.package;
-      default = clientDefaultPackage;
-      defaultText = lib.literalExpression ''
-        parsec-cloud.packages.''${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v2-client
-      '';
-      description = ''
-        Parsec-cloud client package to use. Defaults to the one provided by the flake.
-      '';
-    };
-
-    telemetry = mkOption {
-      type = types.bool;
-      default = true;
-      example = false;
-      description = "Wheter to enable telemetry";
-    };
-
-    lang = mkOption {
-      type = types.str;
-      default = "en";
-      example = "fr";
-      description = "Language to use";
-    };
-
-    preferredServer = mkOption {
-      type = types.str;
-      default = "parsec://saas.parsec.cloud";
-      example = "parsec://myserver.com";
-      description = "Preferred server to create organization to";
-    };
-
-    dataBaseDir = mkOption {
-      type = types.path;
-      default = "${config.xdg.dataHome}/parsec";
-      example = "~/.parsec/data";
-      description = "Directory to store data";
-    };
-
-    mountpoint = {
-      baseDir = mkOption {
-        # In reality, this value could be null and it will default to ~/Parsec.
-        # but instead we use the default value of the option to make it explicit.
-        type = types.path;
-        default = "${config.home.homeDirectory}/Parsec";
-        example = "~/Documents/Parsec";
-        description = "Directory to mount your parsec workspaces";
+      package = mkOption {
+        type = types.package;
+        default = clientDefaultPackage;
+        defaultText = lib.literalExpression ''
+          parsec-cloud.packages.''${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v2-client
+        '';
+        description = ''
+          Parsec-cloud client package to use. Defaults to the one provided by the flake.
+        '';
       };
 
-      enable = mkOption {
+      telemetry = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = "Wheter to enable telemetry";
+      };
+
+      lang = mkOption {
+        type = types.str;
+        default = "en";
+        example = "fr";
+        description = "Language to use";
+      };
+
+      preferredServer = mkOption {
+        type = types.str;
+        default = "parsec://saas.parsec.cloud";
+        example = "parsec://myserver.com";
+        description = "Preferred server to create organization to";
+      };
+
+      dataBaseDir = mkOption {
+        type = types.path;
+        default = "${config.xdg.dataHome}/parsec";
+        example = "~/.parsec/data";
+        description = "Directory to store data";
+      };
+
+      mountpoint = {
+        baseDir = mkOption {
+          # In reality, this value could be null and it will default to ~/Parsec.
+          # but instead we use the default value of the option to make it explicit.
+          type = types.path;
+          default = "${config.home.homeDirectory}/Parsec";
+          example = "~/Documents/Parsec";
+          description = "Directory to mount your parsec workspaces";
+        };
+
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = ''
+            Enable or disable mountpoint
+
+            > Note: The application will enable that option on certain commands (like starting the GUI)
+          '';
+        };
+      };
+
+      firstLaunchMessage = mkOption {
         type = types.bool;
         default = false;
         example = true;
-        description = ''
-          Enable or disable mountpoint
-
-          > Note: The application will enable that option on certain commands (like starting the GUI)
-        '';
+        description = "Display first launch's welcome message";
       };
-    };
 
-    firstLaunchMessage = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = "Display first launch's welcome message";
-    };
-
-    sentry = {
-      dsn = mkOption {
-        type = types.str;
-        default = "https://863e60bbef39406896d2b7a5dbd491bb@o155936.ingest.sentry.io/1212848";
-        example = "https://foobar.ingest.my-sentry-dsn.com/random_id";
-        description = "Sentry DSN";
+      sentry = {
+        dsn = mkOption {
+          type = types.str;
+          default = "https://863e60bbef39406896d2b7a5dbd491bb@o155936.ingest.sentry.io/1212848";
+          example = "https://foobar.ingest.my-sentry-dsn.com/random_id";
+          description = "Sentry DSN";
+        };
+        environment = mkOption {
+          type = types.str;
+          default = "production";
+          example = "staging";
+          description = "Sentry environment";
+        };
       };
-      environment = mkOption {
-        type = types.str;
-        default = "production";
-        example = "staging";
-        description = "Sentry environment";
-      };
-    };
 
-
-    preventSyncPatternFile = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      example = "~/.config/parsec/custom-prevent-sync-pattern";
-      description = ''
-        File containing file pattern that we don't want to sync.
-        The file format is similar to `.gitignore`.
-      '';
-    };
-
-    backend = {
-      maxCooldown = mkOption {
-        type = types.int;
-        default = 30;
-        example = 60;
-        description = "Maximum duration between reconnection attempts in case of a connection lost with the server";
-      };
-      keepAlive = mkOption {
-        # In reality that option could be null and it will default to 29.
-        type = types.int;
-        default = 29;
-        example = 15;
-        description = "interval in seconds between keepalive messages sent to the server";
-      };
-      maxConnections = mkOption {
-        # TODO: Assert the value is greater or equal to 2
-        type = types.int;
-        default = 4;
-        example = 8;
-        description = "Maximum connections to the server";
-      };
-    };
-
-    personalWorkspace = {
-      baseDir = mkOption {
+      preventSyncPatternFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = "~/Documents/Parsec/Personal";
-        description = "Directory to store personal workspaces";
-      };
-      namePattern = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "PersonalWorkspace";
-        description = "Pattern of personal workspaces";
-      };
-    };
-
-    workspaceStorageCacheSize = mkOption {
-      type = types.int;
-      default = 512 * 1024 * 1024;
-      example = 1024 * 1024 * 1024;
-      description = "Size of the workspace storage cache";
-    };
-
-    lastDevice = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "30ceb836cc786ea71605698c45f6d62a0dd4a0ab7fe3a379380a6ca0a4146d0a";
-      description = ''
-        The ID of the last device used.
-        This will put the said device at the top of the list of devices.
-
-        > The id of a device can be retrieved with `parsec core list_devices`.
-      '';
-    };
-
-    enableTray = mkOption {
-      type = types.bool;
-      default = true;
-      example = false;
-      description = "Allow to put the application in the system tray";
-    };
-
-    version = {
-      last = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        # example = builtins.toString clientDefaultPackage.version;
-        example = lib.debug.traceSeq clientDefaultPackage.version "0.0.1";
-        description = "Last version of the application used";
-      };
-
-      checkForUpdate = mkOption {
-        type = types.bool;
-        default = true;
-        example = false;
-        description = "Check for update on start";
-      };
-
-      allowPreRelease = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
-        description = "Allow pre-release version when checking for new version";
-      };
-
-      apiURL = mkOption {
-        type = types.str;
-        default = "https://api.github.com/repos/Scille/parsec-cloud/releases";
-        description = "API URL to check for update";
-      };
-    };
-
-    gui = {
-      askBeforeClose = mkOption {
-        type = types.bool;
-        default = true;
-        example = false;
-        description = "Ask for confirmation before closing the application";
-      };
-
-      showConfined = mkOption {
-        type = types.bool;
-        default = false;
-        example = true;
+        example = "~/.config/parsec/custom-prevent-sync-pattern";
         description = ''
-          Show confined files in the file manager.
-
-          > Confined files are not synced with the server.
+          File containing file pattern that we don't want to sync.
+          The file format is similar to `.gitignore`.
         '';
       };
 
-      geometry = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "Geometry of the GUI encoded in base64 to be used when starting up";
+      backend = {
+        maxCooldown = mkOption {
+          type = types.int;
+          default = 30;
+          example = 60;
+          description = "Maximum duration between reconnection attempts in case of a connection lost with the server";
+        };
+        keepAlive = mkOption {
+          # In reality that option could be null and it will default to 29.
+          type = types.int;
+          default = 29;
+          example = 15;
+          description = "interval in seconds between keepalive messages sent to the server";
+        };
+        maxConnections = mkOption {
+          # TODO: Assert the value is greater or equal to 2
+          type = types.int;
+          default = 4;
+          example = 8;
+          description = "Maximum connections to the server";
+        };
       };
 
-      hideUnmounted = mkOption {
+      personalWorkspace = {
+        baseDir = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "~/Documents/Parsec/Personal";
+          description = "Directory to store personal workspaces";
+        };
+        namePattern = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "PersonalWorkspace";
+          description = "Pattern of personal workspaces";
+        };
+      };
+
+      workspaceStorageCacheSize = mkOption {
+        type = types.int;
+        default = 512 * 1024 * 1024;
+        example = 1024 * 1024 * 1024;
+        description = "Size of the workspace storage cache";
+      };
+
+      lastDevice = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "30ceb836cc786ea71605698c45f6d62a0dd4a0ab7fe3a379380a6ca0a4146d0a";
+        description = ''
+          The ID of the last device used.
+          This will put the said device at the top of the list of devices.
+
+          > The id of a device can be retrieved with `parsec core list_devices`.
+        '';
+      };
+
+      enableTray = mkOption {
         type = types.bool;
-        default = false;
-        example = true;
-        description = "Hide unmounted workspaces in the GUI";
+        default = true;
+        example = false;
+        description = "Allow to put the application in the system tray";
+      };
+
+      version = {
+        last = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          # example = builtins.toString clientDefaultPackage.version;
+          example = lib.debug.traceSeq clientDefaultPackage.version "0.0.1";
+          description = "Last version of the application used";
+        };
+
+        checkForUpdate = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = "Check for update on start";
+        };
+
+        allowPreRelease = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = "Allow pre-release version when checking for new version";
+        };
+
+        apiURL = mkOption {
+          type = types.str;
+          default = "https://api.github.com/repos/Scille/parsec-cloud/releases";
+          description = "API URL to check for update";
+        };
+      };
+
+      gui = {
+        askBeforeClose = mkOption {
+          type = types.bool;
+          default = true;
+          example = false;
+          description = "Ask for confirmation before closing the application";
+        };
+
+        showConfined = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = ''
+            Show confined files in the file manager.
+
+            > Confined files are not synced with the server.
+          '';
+        };
+
+        geometry = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Geometry of the GUI encoded in base64 to be used when starting up";
+        };
+
+        hideUnmounted = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = "Hide unmounted workspaces in the GUI";
+        };
       };
     };
-  };
 
   config =
     let
@@ -245,12 +254,19 @@ in
         terminal = false;
         startupNotify = false;
         startupWMClass = "Parsec";
-        categories = [ "Network" "FileTransfer" "Security" ];
+        categories = [
+          "Network"
+          "FileTransfer"
+          "Security"
+        ];
         mimeTypes = [ "x-scheme-handler/parsec" ];
       };
     in
     lib.mkIf cfgClient.enable {
-      home.packages = [ client desktopItem ];
+      home.packages = [
+        client
+        desktopItem
+      ];
 
       # Parsec cloud configuration can be found here.
       # https://github.com/Scille/parsec-cloud/blob/d639f80bc10fb0dff506ac123b3eb205f23e1690/parsec/core/config.py#L48-L197

--- a/packages/v3/home-manager-module.nix
+++ b/packages/v3/home-manager-module.nix
@@ -1,23 +1,33 @@
-self: { lib, pkgs, config, ... }:
+self:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 
 let
   clientDefaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v3-client;
 in
 {
-  options.programs.parsec-cloud-v3-client = let inherit (lib) mkEnableOption mkOption types; in {
-    enable = mkEnableOption "parsec-cloud-v3-client";
+  options.programs.parsec-cloud-v3-client =
+    let
+      inherit (lib) mkEnableOption mkOption types;
+    in
+    {
+      enable = mkEnableOption "parsec-cloud-v3-client";
 
-    package = mkOption {
-      type = types.package;
-      default = clientDefaultPackage;
-      defaultText = lib.literalExpression ''
-        parsec-cloud.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v3-client
-      '';
-      description = ''
-        Parsec-cloud client package to use. Defaults to the one provided by the flake.
-      '';
+      package = mkOption {
+        type = types.package;
+        default = clientDefaultPackage;
+        defaultText = lib.literalExpression ''
+          parsec-cloud.packages.${pkgs.stdenv.hostPlatform.system}.parsec-cloud-v3-client
+        '';
+        description = ''
+          Parsec-cloud client package to use. Defaults to the one provided by the flake.
+        '';
+      };
     };
-  };
 
   config =
     let
@@ -32,7 +42,12 @@ in
         exec = "${client}/bin/parsec %U";
         inherit icon;
         terminal = false;
-        categories = [ "Office" "FileTransfer" "Filesystem" "Security" ];
+        categories = [
+          "Office"
+          "FileTransfer"
+          "Filesystem"
+          "Security"
+        ];
         mimeTypes = [ "x-scheme-handler/parsec${clientMajorVersion}" ];
       };
     in

--- a/packages/v3/libparsec-node.nix
+++ b/packages/v3/libparsec-node.nix
@@ -14,7 +14,6 @@
   cargoBuildFeatures = [ ];
 
   cargoLock.lockFile = "${src}/Cargo.lock";
-  cargoHash = pkgs.lib.fakeHash;
 
   doCheck = false;
 

--- a/packages/v3/parsec-cli.nix
+++ b/packages/v3/parsec-cli.nix
@@ -1,0 +1,31 @@
+{ pkgs, version, src, rust-toolchain, system, ... }:
+
+(pkgs.makeRustPlatform {
+  cargo = rust-toolchain;
+  rustc = rust-toolchain;
+}).buildRustPackage {
+  inherit version src;
+  pname = "parsec-cli";
+
+  cargoLock.lockFile = src + "/Cargo.lock";
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [
+    pkgs.openssl.dev
+    pkgs.sqlite.dev
+    pkgs.dbus.dev
+    pkgs.fuse3.dev
+  ];
+
+  # Require running the `testbed` server to run the tests (+ access to `parsec-cli`).
+  doCheck = false;
+
+  meta = let inherit (pkgs.lib) majorMinor licenses; in {
+    homepage = "https://parsec.cloud/";
+    description = "Parsec CLI";
+    branch = "releases/${majorMinor version}";
+    license = [ licenses.bsl11 ];
+    changelog = "https://github.com/Scille/parsec-cloud/tree/v${version}/HISTORY.rst";
+    platforms = [ system ];
+  };
+}


### PR DESCRIPTION
- Rename exported package to use dot (`.`) between project, version and type.
- Format modified files.

Closes #67