### PR TITLE
fix(cli): Only compile `parsec-cli` crate

### DIFF
--- a/packages/v3/parsec-cli.nix
+++ b/packages/v3/parsec-cli.nix
@@ -1,31 +1,44 @@
-{ pkgs, version, src, rust-toolchain, system, ... }:
+{
+  pkgs,
+  version,
+  src,
+  rust-toolchain,
+  system,
+  ...
+}:
 
 (pkgs.makeRustPlatform {
   cargo = rust-toolchain;
   rustc = rust-toolchain;
-}).buildRustPackage {
-  inherit version src;
-  pname = "parsec-cli";
+}).buildRustPackage
+  {
+    inherit version src;
+    pname = "parsec-cli";
 
-  cargoLock.lockFile = src + "/Cargo.lock";
+    cargoLock.lockFile = src + "/Cargo.lock";
 
-  nativeBuildInputs = [ pkgs.pkg-config ];
-  buildInputs = [
-    pkgs.openssl.dev
-    pkgs.sqlite.dev
-    pkgs.dbus.dev
-    pkgs.fuse3.dev
-  ];
+    nativeBuildInputs = [ pkgs.pkg-config ];
+    buildInputs = [
+      pkgs.openssl.dev
+      pkgs.sqlite.dev
+      pkgs.dbus.dev
+      pkgs.fuse3.dev
+    ];
 
-  # Require running the `testbed` server to run the tests (+ access to `parsec-cli`).
-  doCheck = false;
+    buildAndTestSubdir = "cli";
+    # Require running the `testbed` server to run the tests (+ access to `parsec-cli`).
+    doCheck = false;
 
-  meta = let inherit (pkgs.lib) majorMinor licenses; in {
-    homepage = "https://parsec.cloud/";
-    description = "Parsec CLI";
-    branch = "releases/${majorMinor version}";
-    license = [ licenses.bsl11 ];
-    changelog = "https://github.com/Scille/parsec-cloud/tree/v${version}/HISTORY.rst";
-    platforms = [ system ];
-  };
-}
+    meta =
+      let
+        inherit (pkgs.lib) majorMinor licenses;
+      in
+      {
+        homepage = "https://parsec.cloud/";
+        description = "Parsec CLI";
+        branch = "releases/${majorMinor version}";
+        license = [ licenses.bsl11 ];
+        changelog = "https://github.com/Scille/parsec-cloud/tree/v${version}/HISTORY.rst";
+        platforms = [ system ];
+      };
+  }


### PR DESCRIPTION
- The CLI included code compiled with the testbed feature which is something you do not want for a production releases.