### PR TITLE
refactor: Rename `sha256` to `hash` attribute in fetcher

### DIFF
--- a/packages/v3/capacitor-electron.nix
+++ b/packages/v3/capacitor-electron.nix
@@ -11,7 +11,7 @@ buildNpmPackage {
     owner = "Scille";
     repo = "capacitor-electron";
     rev = "415b25cb411ac3957a3d5d25d2a68e5f350161cb";
-    sha256 = "sha256-CdON+bWmVeVHVUjBcq3dnWPQL3YB2dGR2Of1R4lvlDA=";
+    hash = "sha256-CdON+bWmVeVHVUjBcq3dnWPQL3YB2dGR2Of1R4lvlDA=";
   };
 
   npmDepsHash = "sha256-IFlElWNT5SWid08kYiFUZ3eox7lfpbvAZrHPvjSiWRE=";

--- a/packages/v3/source.nix
+++ b/packages/v3/source.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
     repo = "parsec-cloud";
     tag = "v${version}";
     # `nix-prefetch-url --unpack https://github.com/${owner}/${repo}/archive/${commit_rev}.tar.gz`
-    sha256 = "sha256-vcZ/zPkpw8x+K/AGVxgmYxjoSKtzxVBDAk5P1nBcSSA=";
+    hash = "sha256-vcZ/zPkpw8x+K/AGVxgmYxjoSKtzxVBDAk5P1nBcSSA=";
   };
   patches = [
   ];


### PR DESCRIPTION
https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs-fetchers-fetchurl-inputs Indicates that `hash` should be prefered over other means to provide the hash.

Previous attribute (like `sha256`) are keep for backwards compat